### PR TITLE
Make nutsdb conf path understand CBSTORE_ROOT

### DIFF
--- a/conf/store_conf.yaml
+++ b/conf/store_conf.yaml
@@ -6,7 +6,7 @@ storetype: NUTSDB
 #storetype: ETCD
 
 nutsdb:
-  dbpath: "~/go/src/github.com/cloud-barista/cb-store/meta_db/dat"
+  dbpath: "$CBSTORE_ROOT/meta_db/dat"
   segmentsize: 1048576  # 1048576 1024*1024 (1MB)
   #segmentsize: 10485760  # 10485760 10*1024*1024 (10MB)
 

--- a/store-drivers/nutsdb-driver/nutsdb-driver.go
+++ b/store-drivers/nutsdb-driver/nutsdb-driver.go
@@ -10,6 +10,8 @@ package cbstore
 import (
 	"io/ioutil"
 	"os"
+	"strings"
+	"fmt"
 
 	"github.com/cloud-barista/cb-store/config"
 	"github.com/xujiajun/nutsdb"
@@ -27,8 +29,19 @@ func init() {
 	initialize()
 }
 
+func getFileDir() string {
+	fileDir := config.GetConfigInfos().NUTSDB.DBPATH
+	config.Cblogger.Info("######## dbfile: " + fileDir)
+
+	cbstoreRootPath := os.Getenv("CBSTORE_ROOT")
+	fileDir = strings.Replace(fileDir, "$CBSTORE_ROOT", cbstoreRootPath, 1)
+
+	return fileDir
+}
+
 func initialize() {
-        fileDir := config.GetConfigInfos().NUTSDB.DBPATH
+		fmt.Println("getFileDir(): " + getFileDir())
+        fileDir := getFileDir()
         config.Cblogger.Info("######## dbfile: " + fileDir)
 
         opt := nutsdb.DefaultOptions
@@ -42,7 +55,7 @@ func initialize() {
 
 // If InitDB will be done online by other process, this is not effective until restart.
 func (nutsdbDriver *NUTSDBDriver) InitDB() error {
-	fileDir := config.GetConfigInfos().NUTSDB.DBPATH
+	fileDir := getFileDir()
         files, _ := ioutil.ReadDir(fileDir)
         for _, f := range files {
                 name := f.Name()

--- a/store-drivers/nutsdb-driver/nutsdb-driver.go
+++ b/store-drivers/nutsdb-driver/nutsdb-driver.go
@@ -40,7 +40,7 @@ func getFileDir() string {
 }
 
 func initialize() {
-		fmt.Println("getFileDir(): " + getFileDir())
+		fmt.Println("[DB file path] " + getFileDir())
         fileDir := getFileDir()
         config.Cblogger.Info("######## dbfile: " + fileDir)
 


### PR DESCRIPTION

This PR makes a function to get dbpath of nutsdb in the conf/store_conf.yaml.

The func will understand $CBSTORE_ROOT (environment variable) written in nutsdb path in the conf/store_conf.yaml.